### PR TITLE
Set the selected Rails version based on the generated guides version

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -65,10 +65,6 @@
     document.addEventListener("scroll", toggleBackToTop);
 
     var guidesVersion = document.querySelector("select.guides-version");
-    each(guidesVersion.querySelectorAll("option"), function(element) {
-      element.selected = window.location.href.startsWith(element.value);
-    });
-
     guidesVersion.addEventListener("change", function(e) {
       Turbo.visit(e.target.value);
     });

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -54,21 +54,10 @@
           <span id="version_switcher">
             Version:
             <select class="guides-version">
-              <option value="https://edgeguides.rubyonrails.org/" selected>Edge</option>
-              <option value="https://guides.rubyonrails.org/v7.1">7.1</option>
-              <option value="https://guides.rubyonrails.org/v7.0">7.0</option>
-              <option value="https://guides.rubyonrails.org/v6.1">6.1</option>
-              <option value="https://guides.rubyonrails.org/v6.0">6.0</option>
-              <option value="https://guides.rubyonrails.org/v5.2">5.2</option>
-              <option value="https://guides.rubyonrails.org/v5.1">5.1</option>
-              <option value="https://guides.rubyonrails.org/v5.0">5.0</option>
-              <option value="https://guides.rubyonrails.org/v4.2">4.2</option>
-              <option value="https://guides.rubyonrails.org/v4.1">4.1</option>
-              <option value="https://guides.rubyonrails.org/v4.0">4.0</option>
-              <option value="https://guides.rubyonrails.org/v3.2">3.2</option>
-              <option value="https://guides.rubyonrails.org/v3.1">3.1</option>
-              <option value="https://guides.rubyonrails.org/v3.0">3.0</option>
-              <option value="https://guides.rubyonrails.org/v2.3">2.3</option>
+              <option value="https://edgeguides.rubyonrails.org/"<%= " selected" if @edge %>>Edge</option>
+              <% %w[7.1 7.0 6.1 6.0 5.2 5.1 5.0 4.2 4.1 4.0 3.2 3.1 3.0 2.3].each do |version| %>
+                <option value="https://guides.rubyonrails.org/v<%= version %>/"<%= " selected" if @version&.start_with?(version) %>><%= version %></option>
+              <% end %>
             </select>
           </span>
         </div>


### PR DESCRIPTION
Instead of setting it dynamically via JS, use the known version that the guide is being generated with, or edge, to determine the selected Rails version in the version dropdown.

Since each version is set when generating the guides, we can "hardcode" the selected version upon guides generation, instead of using JS to set it dynamically.

Ref.: https://github.com/rails/rails/pull/51341#discussion_r1529303611

### Samples

<details><summary>rake guides:generate</summary>
<p>

<img width="1007" alt="Screenshot 2024-03-19 at 15 43 33" src="https://github.com/jathayde/rails/assets/26328/812e43ee-e024-4eb2-8c7b-98a5c1dab7d5">

</p>
</details> 


<details><summary>RAILS_VERSION=7.1 rake guides:generate</summary>
<p>

<img width="985" alt="Screenshot 2024-03-19 at 15 42 58" src="https://github.com/jathayde/rails/assets/26328/a39bd35e-e82a-49b0-b389-d3b9497bf5b6">

</p>
</details> 


<details><summary>RAILS_VERSION=7.0 rake guides:generate</summary>
<p>

<img width="972" alt="Screenshot 2024-03-19 at 15 43 18" src="https://github.com/jathayde/rails/assets/26328/6143340f-2b67-4424-b666-b1d83ef236c4">

</p>
</details> 